### PR TITLE
LPS-145168 Translation name over side bar

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/css/_portlet-forms-admin.scss
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/css/_portlet-forms-admin.scss
@@ -10,6 +10,16 @@
 	}
 }
 
+.ddm-translation-manager {
+	.lfr-translationmanager {
+		width: 70%;
+		z-index: 0;
+		@media screen and (max-width: 1180px) {
+			width: 50%;
+		}
+	}
+}
+
 .error-icon {
 	color: #da1414;
 	margin-right: 5px;


### PR DESCRIPTION
Hello Reviewer! 
Related Issue: https://issues.liferay.com/browse/LPS-145168

This PR has a fix of the bug above. For the solution I used a media query, to break the line in a given 'px' not letting it stay below the side bar
