### PR TITLE
LPS-144284 Fix remove key if value zero

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/report/DDMFormFieldTypeReportProcessor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/report/DDMFormFieldTypeReportProcessor.java
@@ -58,7 +58,14 @@ public interface DDMFormFieldTypeReportProcessor {
 					DDMFormInstanceReportConstants.
 						EVENT_DELETE_RECORD_VERSION)) {
 
-			jsonObject.put(key, jsonObject.getInt(key, 0) - 1);
+			int value = jsonObject.getInt(key, 0) - 1;
+
+			if (value > 0) {
+				jsonObject.put(key, value);
+			}
+			else {
+				jsonObject.remove(key);
+			}
 		}
 	}
 


### PR DESCRIPTION
Related Issue: [LPS-144284](https://issues.liferay.com/browse/LPS-144284)

When the vote is removed the form, the method responsible for delete only remove vote. If total votes is zero, the method need remove key. That way, in portal show "There are no entries.".