### PR TITLE
LPS-151043 removed delete event for delete key not to delete assignment

### DIFF
--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/SidebarHeader.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/SidebarHeader.js
@@ -61,7 +61,7 @@ export default function SidebarHeader({
 
 	const handleKeyDown = (event) => {
 		if (
-			(event.key === 'Backspace' || event.key === 'Delete') &&
+			(event.key === 'Backspace') &&
 			document.querySelectorAll('.form-control:focus').length === 0 &&
 			document.querySelectorAll('.CodeMirror-focused').length === 0
 		) {


### PR DESCRIPTION
Related Issue: https://issues.liferay.com/browse/LPS-151043

This PR fixes the bug above, when pressing the delete key, the modal opened asking if the user wanted to delete the assignment. to resvolve I just removed the **_"event.key === 'Delete' ",_** so when pressing delete on the keyboard the delete modal is not displayed. Doubts, tips, you can get in touch. Thanks