### PR TITLE
LPS-147632 Removing auto-fill empty when selecting Role

### DIFF
--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/sections/shared-components/BaseRole.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/sections/shared-components/BaseRole.js
@@ -56,7 +56,6 @@ export default function BaseRole({
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [defaultFieldValue]);
 
-	const initialLoading = networkStatus === 1;
 	const loading = networkStatus < 4;
 	const error = networkStatus === 5;
 
@@ -104,7 +103,7 @@ export default function BaseRole({
 					/>
 
 					<ClayAutocomplete.DropDown
-						active={(!!resource && active) || initialLoading}
+						active={!!resource && active}
 						closeOnClickOutside
 						onSetActive={setActive}
 					>


### PR DESCRIPTION
In this bug, it is requested to remove the loading bar, when the role option is selected, but the loading bar will only appear on the first access.
So to be able to check if it is running and you have to do more than one check, close catalina and open it again for each test.