### PR TITLE
LPS-152741 - Generic error is shown when admin tries to set a big folder name for Docs and Media attachment path

### DIFF
--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/EditObjectField.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/EditObjectField.tsx
@@ -95,7 +95,7 @@ export default function EditObjectField({
 
 			const message =
 				(error?.type && ERRORS[error.type]) ??
-				Liferay.Language.get('an-error-occurred');
+				Liferay.Language.get('maximum-number-of-characters');
 
 			openToast({message, type: 'danger'});
 		}


### PR DESCRIPTION
An Generic error message is shown when tries to set a big folder name:  "An error occurred". I changed message to: "Maximum number of characters".
link LPS: https://issues.liferay.com/secure/RapidBoard.jspa?rapidView=6889&view=detail&selectedIssue=LPS-152741&quickFilter=41284