### PR TITLE
LPS-144105 - Partial Results warning message is not aligned on Entries tab of form builder

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/util/ShowPartialResultsAlert.scss
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/util/ShowPartialResultsAlert.scss
@@ -1,5 +1,5 @@
 .lfr-ddm__show-partial-results-alert {
-	padding-top: 16px;
+	padding: 0;
 
 	&--hidden {
 		display: none;


### PR DESCRIPTION
Description: I correct the warning message removed the padding space.
link LPS: https://issues.liferay.com/browse/LPS-144105