### PR TITLE
LPS-155094 - Autofill suggestion from Google Chrome is floating when user is scrolling on Objects settings fields

### DIFF
--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModalAddObjectField.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModalAddObjectField.tsx
@@ -97,6 +97,7 @@ function ModalAddObjectField({
 					)}
 
 					<Input
+						autoComplete="off"
 						error={errors.label}
 						label={Liferay.Language.get('label')}
 						name="label"

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectFieldFormBase.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectFieldFormBase.tsx
@@ -210,6 +210,7 @@ export default function ObjectFieldFormBase({
 	return (
 		<>
 			<Input
+				autoComplete="off"
 				disabled={disabled}
 				error={errors.name}
 				label={Liferay.Language.get('field-name')}


### PR DESCRIPTION
I changed the autoComplete to off because this behavior happened in autocomplete class,  by default the autocomplete in  have four arguments: none, inline, list and both. In my analytics this behavior happens in several places in the portal, because the auto complete is standard. And others components in Objects module it's using how "off", example the ModalAddObjectValidation.
LINK LPS: https://issues.liferay.com/browse/LPS-155094