### PR TITLE
LPS-147482 Collision warning (red border) is kept when node leaves diagram builder while colliding

### DIFF
--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/nodes/BaseNode.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/nodes/BaseNode.js
@@ -52,9 +52,12 @@ export default function BaseNode({
 	const targethandlesRef = useRef();
 	const {selectedLanguageId} = useContext(DefinitionBuilderContext);
 
-	const {collidingElements, selectedItem, setSelectedItem} = useContext(
-		DiagramBuilderContext
-	);
+	const {
+		collidingElements,
+		selectedItem,
+		setCollidingElements,
+		setSelectedItem,
+	} = useContext(DiagramBuilderContext);
 
 	useEffect(() => {
 		if (sourcehandlesRef?.current && targethandlesRef?.current) {
@@ -165,6 +168,7 @@ export default function BaseNode({
 			{!descriptionSidebar && (
 				<div
 					className="node-handle-area"
+					onDragLeave={() => setCollidingElements(null)}
 					onMouseEnter={displaySourceHandles(true)}
 					onMouseLeave={displaySourceHandles(false)}
 				>


### PR DESCRIPTION
[LPS-147482](https://issues.liferay.com/browse/LPS-147482)
