### PR TITLE
LPS-151108 Removing sidebar-open css class when derendering

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/pages/FormBuilder.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/pages/FormBuilder.es.js
@@ -433,6 +433,18 @@ export function FormBuilder() {
 			addObjectFields(dispatch);
 		}
 
+		return () => {
+			const alerts = document.querySelector(
+				'.ddm-form-web__exception-container'
+			);
+
+			if (sidebarOpen && alerts) {
+				alerts.className = classNames(
+					'ddm-form-web__exception-container'
+				);
+			}
+		};
+
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 


### PR DESCRIPTION
Hello Reviewer!
Related Issue: https://issues.liferay.com/browse/LPS-151108

When 'desrendering' the forms to align the error in the rules and entries, checked the condition of the sidebar and if there is an error, removed the condition of the padding-right 338px.